### PR TITLE
Print out a warning when a path is not found.

### DIFF
--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -6,6 +6,7 @@ namespace TypistTech\Imposter\Plugin;
 
 use Composer\IO\IOInterface;
 use TypistTech\Imposter\ImposterFactory;
+use TypistTech\Imposter\PathNotFoundException;
 
 class Transformer
 {
@@ -25,7 +26,11 @@ class Transformer
         $index = 1;
         foreach ($autoloads as $autoload) {
             $io->write(" - <comment>$index/$count</comment>: Transforming $autoload", true);
-            $imposter->transform($autoload);
+            try {
+	            $imposter->transform($autoload);
+            } catch (PathNotFoundException $exception) {
+            	$io->write("   <comment>Warning: Path $autoload not found</comment>", true);
+            }
             $index++;
         };
 

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -27,9 +27,9 @@ class Transformer
         foreach ($autoloads as $autoload) {
             $io->write(" - <comment>$index/$count</comment>: Transforming $autoload", true);
             try {
-	            $imposter->transform($autoload);
+                $imposter->transform($autoload);
             } catch (PathNotFoundException $exception) {
-            	$io->write("   <comment>Warning: Path $autoload not found</comment>", true);
+                $io->write("   <comment>Warning: Path $autoload not found</comment>", true);
             }
             $index++;
         };


### PR DESCRIPTION
This handles non existing paths gracefully, printing a warning.

Depends on [PR #152](https://github.com/TypistTech/imposter/pull/152) on TypistTech/imposter