### PR TITLE
Bump version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.2",
         "composer-plugin-api": "^1.1",
-        "typisttech/imposter": "^0.5.0"
+        "typisttech/imposter": "^0.6.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",


### PR DESCRIPTION
Bump version requirement to allow selecting the 0.6.0 imposter release.

A `^` constraint with 3 digits (major.minor.patch) limits versions to the same major and minor.